### PR TITLE
fixed sending of MAV_ADSB_VEHICLE

### DIFF
--- a/main/gps.cpp
+++ b/main/gps.cpp
@@ -588,7 +588,7 @@ static void GPS_MAV(void)                                                  // wh
   uint64_t UnixTime_ms = MAV_getUnixTime();                                   // get the time from the MAVlink message
   if( (MsgID!=MAV_ID_SYSTEM_TIME) && UnixTime_ms)
   { if(Position[PosIdx].hasTime)
-    { uint64_t PrevUnixTime_ms = 1000*(uint64_t)Position[PosIdx].getUnixTime()+10*(uint32_t)Position[PosIdx].FracSec; // Position[PosIdx].getUnixTime_ms();
+    { uint64_t PrevUnixTime_ms = Position[PosIdx].getUnixTime_ms();
       int32_t TimeDiff_ms = UnixTime_ms-PrevUnixTime_ms;
 #ifdef DEBUG_PRINT
     xSemaphoreTake(CONS_Mutex, portMAX_DELAY);

--- a/main/ogn.h
+++ b/main/ogn.h
@@ -985,7 +985,8 @@ class GPS_Position
      return TimeDiff; } // [0.01s]
 
    void Write(MAV_GPS_RAW_INT *MAV) const
-   { MAV->time_usec = (int64_t)1000000*getUnixTime()+10000*FracSec;
+//   { MAV->time_usec = (int64_t)1000000*getUnixTime()+10000*FracSec;
+   { MAV->time_usec = getUnixTime_ms()*1000; // (int64_t)1000000*getUnixTime()+10000*FracSec;
      MAV->lat = ((int64_t)50*Latitude+1)/3;
      MAV->lon = ((int64_t)50*Longitude+1)/3;
      MAV->alt = 100*Altitude;
@@ -1317,6 +1318,10 @@ class GPS_Position
   { uint32_t Time=Time_ms/1000;
     setUnixTime(Time);
     FracSec = (Time_ms-(uint64_t)Time*1000)/10; }
+
+  uint64_t getUnixTime_ms(void) const
+  { return (uint64_t)getUnixTime()*1000 + (uint32_t)FracSec*10; }
+
 
   private:
 


### PR DESCRIPTION
For some reason the improvements you made for Mavlink and ADSB_VEHICLE messages last year were lost since the major update of January 2019.
Should be fixed now. ADSB_VEHICLE messages are sent to the flight controller and further to the ground control station.