### PR TITLE
Charge Mode functionality

### DIFF
--- a/main/config.h
+++ b/main/config.h
@@ -26,6 +26,8 @@
 
 // #define WITH_SLEEP                         // with software sleep mode controlled by the long-press on the button
 
+// #define WITH_CHARGE_MODE                   // Charge mode for those device which can not be charge without turning them on, like the TTGO. On boot the U8G2_OLED will display a message and charge mode can be entered by pressing the PRG button.
+
 #define WITH_AXP                           // with AXP192 power controller (T-BEAM V1.0)
 // #define WITH_BQ                            // with BQ24295  power controller (FollowMe)
 

--- a/main/hal.h
+++ b/main/hal.h
@@ -161,6 +161,7 @@ void LED_TimerCheck(uint8_t Ticks=1);
 
 // extern bool Button_SleepRequest;
 int32_t Button_TimerCheck(uint8_t Ticks=1);
+bool Button_isPressed(void);
 
 void IO_Configuration(void);             // Configure I/O
 
@@ -209,6 +210,16 @@ extern AXP192 AXP;
 
 #ifdef WITH_SLEEP
 void Sleep(void);
+#endif
+
+#ifdef WITH_CHARGE_MODE
+void Handle_ChargeMode(void);
+
+void displayChargeStartScreen();
+void displayChargeScreen();
+void clearChargeScreen();
+void turnOnDisplay();
+void turnOffDisplay();
 #endif
 
 #endif // __HAL_H__

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -46,6 +46,10 @@ void app_main(void)
 #endif
     IO_Configuration();                      // initialize the GPIO/UART/I2C/SPI for Radio, GPS, OLED, Baro
 
+#ifdef WITH_CHARGE_MODE
+    Handle_ChargeMode();
+#endif
+
 #ifdef WITH_SD
     if(SD_isMounted())                       // if SD card succesfully mounted at startup
     { Parameters.SaveToFlash=0;


### PR DESCRIPTION
Charge mode for those device which can not be charge without turning them on, like the TTGO. On boot the U8G2_OLED will display a message and charge mode can be entered by pressing the PRG button.

Currently only implemented for the U8G2 OLED. LCD implementation should be added.

#17 is the issue linked to this PR