### PR TITLE
Display tweaks

### DIFF
--- a/main/disp_oled.cpp
+++ b/main/disp_oled.cpp
@@ -744,10 +744,10 @@ void OLED_DrawAltitudeAndSpeed(u8g2_t *OLED, GPS_Position *GPS)
   Line[Len]=0;
   u8g2_SetFont(OLED, u8g2_font_fub20_tr);
   uint8_t Altitude_width = u8g2_GetStrWidth(OLED, Line);
-  u8g2_DrawStr(OLED, 54-Altitude_width, 40, Line);
+  u8g2_DrawStr(OLED, 62-Altitude_width, 40, Line);
 
   u8g2_SetFont(OLED, u8g2_font_9x15_tr);
-  u8g2_DrawStr(OLED, 58, 40, "m");
+  u8g2_DrawStr(OLED, 66, 40, "m");
 
   u8g2_SetFont(OLED, u8g2_font_fub17_tr);
   if(GPS && GPS->isValid())
@@ -757,10 +757,10 @@ void OLED_DrawAltitudeAndSpeed(u8g2_t *OLED, GPS_Position *GPS)
     Len=Format_String(Line, "---");
   Line[Len]=0;
   uint8_t Track_width = u8g2_GetStrWidth(OLED, Line);
-  u8g2_DrawStr(OLED, 116-Track_width, 40, Line);
+  u8g2_DrawStr(OLED, 118-Track_width, 40, Line);
 
   u8g2_SetFont(OLED, u8g2_font_6x12_tr);
-  u8g2_DrawStr(OLED, 120, 28, "o");
+  u8g2_DrawStr(OLED, 122, 28, "o");
 
   if(GPS && (GPS->hasBaro || GPS->isValid()))    // if GPS has lock or just the pressure data
   { int16_t vario_value = GPS->ClimbRate;        // [0.1m/s] climb rate

--- a/main/disp_oled.cpp
+++ b/main/disp_oled.cpp
@@ -23,6 +23,10 @@
 #include "wifi.h"
 #endif
 
+#ifdef WITH_AP
+#include "wifi.h"
+#endif
+
 #ifdef WITH_BT_SPP
 #include "bt.h"
 #endif
@@ -592,6 +596,11 @@ void OLED_DrawStatusBar(u8g2_t *OLED, GPS_Position *GPS)   // status bar on top 
   if(WIFI_isConnected())
   { u8g2_SetFont(OLED, u8g2_font_open_iconic_all_1x_t);
     u8g2_DrawGlyph(OLED, 43, 11, 0x119); } // 0x50
+#endif
+#ifdef WITH_AP
+  if(WIFI_isAP())
+  { u8g2_SetFont(OLED, u8g2_font_open_iconic_all_1x_t);
+    u8g2_DrawGlyph(OLED, 43, 11, 0xF8); } // 0x50
 #endif
   // u8g2_SetFont(OLED, u8g2_font_5x7_tr);
   // u8g2_SetFont(OLED, u8g2_font_5x8_tr);

--- a/main/wifi.cpp
+++ b/main/wifi.cpp
@@ -8,6 +8,7 @@ tcpip_adapter_ip_info_t WIFI_IP = { 0, 0, 0 };  // WIFI local IP address, mask a
 WIFI_State_t WIFI_State;
 
 bool WIFI_isConnected(void) { return WIFI_IP.ip.addr!=0; }  // return "connected" status when IP from DHCP is there
+bool WIFI_isAP(void) { return WIFI_Config.ap.ssid_len!=0; }  // return if AP mode enabled
 
 static esp_err_t WIFI_event_handler(void *ctx, system_event_t *event)
 {

--- a/main/wifi.h
+++ b/main/wifi.h
@@ -19,6 +19,7 @@ typedef union
 extern WIFI_State_t WIFI_State;
 
 bool WIFI_isConnected(void);
+bool WIFI_isAP(void);
 esp_err_t WIFI_Init(void);
 esp_err_t WIFI_setPowerSave(bool ON);
 esp_err_t WIFI_Start(void);


### PR DESCRIPTION
Fix the Altitude cutoff issue, and show an icon if AP is enable.

Note, the API icon is a different icon than the WIFI, but they are shown on the same spot. I guess it would never happen to use the both at the same time.